### PR TITLE
fixed and added support for email verification using gmail SMTP

### DIFF
--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -1,1 +1,24 @@
-module.exports = () => ({});
+module.exports = ({ env }) => ({
+  email: {
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: 'smtp.gmail.com',
+        port: 587,
+        auth: {
+          user: env('GMAIL_SMTP_USERNAME', 'strapi'),
+          pass: env('GMAIL_SMTP_PASSWORD', 'strapi'),
+        },
+        tls: {
+            rejectUnauthorized: true,
+            minVersion: 'TLSv1.2',
+            maxVersion: 'TLSv1.3',
+        }
+      },
+      settings: {
+        defaultFrom: env('GMAIL_SMTP_USERNAME', 'strapi'),
+        defaultReplyTo: env('GMAIL_SMTP_USERNAME', 'strapi'),
+      },
+    },
+  },
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@strapi/plugin-users-permissions": "^5.10.3",
+    "@strapi/provider-email-nodemailer": "^5.10.3",
     "@strapi/strapi": "5.9.0",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "11.3.0",
@@ -20,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.27",
+    "nodemailer": "^6.10.0",
     "pg": "^8.13.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
# Add Gmail SMTP Configuration

## Description
Configured email service using Gmail SMTP for TNP Portal to enable email notifications.

## Changelog
- Added `@strapi/provider-email-nodemailer` package
- Configured Gmail SMTP in `config/plugins.js`
- Added email environment variables
- fixes #1 

## Setup
1. Install nodemailer provider
2. Add environment variables
3. Restart server

## Testing
- [x] Test email through admin panel
- [x] Verify environment variables
- [x] Check email delivery